### PR TITLE
Fixed `ParseLink` function return data

### DIFF
--- a/src/Discord/Types/ILinkData.ts
+++ b/src/Discord/Types/ILinkData.ts
@@ -1,6 +1,6 @@
 interface ILinkData {
-    channelID: number,
-    fileID: number,
+    channelID: string,
+    fileID: string,
     fileName: string
 }
 

--- a/src/Discord/Types/ILinkData.ts
+++ b/src/Discord/Types/ILinkData.ts
@@ -1,6 +1,6 @@
 interface ILinkData {
-    channelID: string,
-    fileID: string,
+    channelID: bigint,
+    fileID: bigint,
     fileName: string
 }
 

--- a/src/Discord/Utils/ParseLink.ts
+++ b/src/Discord/Utils/ParseLink.ts
@@ -30,11 +30,13 @@ function ParseLink(input: string): IParsedLink {
     if (!fileName.includes("."))
         return { error: ELinkIssue.FILENAME_NO_DOT };
 
+    console.log(channelID);
+
     return {
         error: ELinkIssue.NONE,
         data: {
-            channelID: channelID,
-            fileID: fileID,
+            channelID: BigInt(channelID),
+            fileID: BigInt(fileID),
             fileName
         }
     }

--- a/src/Discord/Utils/ParseLink.ts
+++ b/src/Discord/Utils/ParseLink.ts
@@ -33,8 +33,8 @@ function ParseLink(input: string): IParsedLink {
     return {
         error: ELinkIssue.NONE,
         data: {
-            channelID: Number(channelID),
-            fileID: Number(fileID),
+            channelID: channelID,
+            fileID: fileID,
             fileName
         }
     }

--- a/src/Discord/Utils/ParseLink.ts
+++ b/src/Discord/Utils/ParseLink.ts
@@ -34,7 +34,7 @@ function ParseLink(input: string): IParsedLink {
         error: ELinkIssue.NONE,
         data: {
             channelID: Number(channelID),
-            fileID: Number(channelID),
+            fileID: Number(fileID),
             fileName
         }
     }


### PR DESCRIPTION
A complete media link (without validation parameters)
```
https://cdn.discordapp.com/attachments/<channelId>/<messageId>/<fileName>
```

Discord's `channelId` and `messageId` are too big for `Number`.  
Converting to `Number` will result in incorrect results.


And fixed typo.